### PR TITLE
Support for availability zone for AWS

### DIFF
--- a/lib/provider_amazon.js
+++ b/lib/provider_amazon.js
@@ -119,6 +119,10 @@
       return this.extract_property('sshPort', node_name);
     };
 
+    _Class.prototype.extract_availability_zone = function(node_name) {
+      return this.extract_property('availabilityZone', node_name);
+    };
+
     _Class.prototype.extract_namespace = function(node_name) {
       /*
       		Extracts a namespace by looking it up in the node itself and upper layers of the manifest
@@ -169,13 +173,14 @@
       		Extracts options related to AWS instances.
       */
 
-      var disable_api_termination, image_id, instance_type, key_name, options, security_groups, user_data;
+      var disable_api_termination, extract_availability_zone, image_id, instance_type, key_name, options, placement, security_groups, user_data;
       image_id = this.extract_image_id(node_name);
       instance_type = this.extract_instance_type(node_name);
       key_name = this.extract_key_name(node_name);
       security_groups = this.extract_security_groups(node_name);
       user_data = this.extract_user_data(node_name);
       disable_api_termination = this.extract_disable_api_termination(node_name);
+      extract_availability_zone = this.extract_availability_zone(node_name);
       options = {};
       if (image_id) {
         options.ImageId = image_id;
@@ -195,6 +200,11 @@
       if (disable_api_termination) {
         options.DisableApiTermination = disable_api_termination;
       }
+      placement = {};
+      if (extract_availability_zone) {
+        placement["AvailabilityZone"] = extract_availability_zone;
+      }
+      options.Placement = placement;
       return options;
     };
 

--- a/src/provider_amazon.coffee
+++ b/src/provider_amazon.coffee
@@ -115,9 +115,8 @@ exports.Provider = class
 		options.SecurityGroups = security_groups if security_groups
 		options.UserData = user_data if user_data
 		options.DisableApiTermination = disable_api_termination if disable_api_termination
-		placement = {}
-		placement["AvailabilityZone"] = extract_availability_zone if extract_availability_zone
-		options.Placement = placement
+		options.Placement = 
+			"AvailabilityZone" : extract_availability_zone if extract_availability_zone
 		
 		return options
 		

--- a/src/provider_amazon.coffee
+++ b/src/provider_amazon.coffee
@@ -59,6 +59,7 @@ exports.Provider = class
 	extract_private_key: (node_name) -> @extract_property 'privateKey', node_name
 	extract_passphrase: (node_name) -> @extract_property 'passphrase', node_name
 	extract_ssh_port: (node_name) -> @extract_property 'sshPort', node_name
+	extract_availability_zone: (node_name) -> @extract_property 'availabilityZone', node_name
 	#
 	#
 	#
@@ -105,6 +106,7 @@ exports.Provider = class
 		security_groups = this.extract_security_groups node_name
 		user_data = this.extract_user_data node_name
 		disable_api_termination = this.extract_disable_api_termination node_name
+		extract_availability_zone = this.extract_availability_zone node_name
 		options = {}
 		
 		options.ImageId = image_id if image_id
@@ -113,6 +115,9 @@ exports.Provider = class
 		options.SecurityGroups = security_groups if security_groups
 		options.UserData = user_data if user_data
 		options.DisableApiTermination = disable_api_termination if disable_api_termination
+		placement = {}
+		placement["AvailabilityZone"] = extract_availability_zone if extract_availability_zone
+		options.Placement = placement
 		
 		return options
 		
@@ -305,6 +310,7 @@ exports.Provider = class
 		#
 		# Next we run the instance.
 		#
+
 		run_instance = (callback) =>
 			options = @extract_instance_options node_name
 			


### PR DESCRIPTION
It has been a requirement in our project to provision a server in a predetermined availability zone. Availability zone is not currently supported, which means that AWS chooses any availability zone according to its own algorithm. This change will optionally enable someone to specify a specific availability zone.
